### PR TITLE
Fix method binding for destructured usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
-        node-version: [20, 22]
+        node-version: [20, 22, 24]
         exclude:
           - os: windows-latest
             node-version: 22
+          - os: windows-latest
+            node-version: 24
 
     steps:
       - name: Check out repo

--- a/index.js
+++ b/index.js
@@ -24,6 +24,30 @@ class Console {
 
     // Add reference to constructor for Node.js Console compatibility
     this.Console = Console
+
+    // Bind all public methods to maintain 'this' context when destructured
+    this.log = this.log.bind(this)
+    this.info = this.info.bind(this)
+    this.warn = this.warn.bind(this)
+    this.error = this.error.bind(this)
+    this.debug = this.debug.bind(this)
+    this.assert = this.assert.bind(this)
+    this.trace = this.trace.bind(this)
+    this.time = this.time.bind(this)
+    this.timeEnd = this.timeEnd.bind(this)
+    this.timeLog = this.timeLog.bind(this)
+    this.count = this.count.bind(this)
+    this.countReset = this.countReset.bind(this)
+    this.group = this.group.bind(this)
+    this.groupCollapsed = this.groupCollapsed.bind(this)
+    this.groupEnd = this.groupEnd.bind(this)
+    this.table = this.table.bind(this)
+    this.dir = this.dir.bind(this)
+    this.dirxml = this.dirxml.bind(this)
+    this.clear = this.clear.bind(this)
+    this.profile = this.profile.bind(this)
+    this.profileEnd = this.profileEnd.bind(this)
+    this.timeStamp = this.timeStamp.bind(this)
   }
 
   // Core logging methods

--- a/test/console.test.js
+++ b/test/console.test.js
@@ -117,3 +117,41 @@ describe('format specifiers', () => {
     assert.strictEqual(logs[0].msg, 'Progress: 50%')
   })
 })
+
+describe('method destructuring', () => {
+  let logs = []
+  const logger = pino({
+    level: 'info'
+  }, {
+    write: (chunk) => {
+      logs.push(JSON.parse(chunk))
+    }
+  })
+  const console = new Console(logger)
+
+  test('destructured log method should work', () => {
+    logs = []
+    const { log } = console
+    log('destructured log message')
+
+    assert.strictEqual(logs.length, 1)
+    assert.strictEqual(logs[0].msg, 'destructured log message')
+  })
+
+  test('destructured methods should maintain correct this context', () => {
+    logs = []
+    const { warn, error, time, timeEnd, count } = console
+
+    warn('warning message')
+    error('error message')
+    time('test')
+    timeEnd('test')
+    count('counter')
+
+    assert.strictEqual(logs.length, 4)
+    assert.strictEqual(logs[0].msg, 'warning message')
+    assert.strictEqual(logs[1].msg, 'error message')
+    assert.ok(logs[2].msg.includes('test:'))
+    assert.strictEqual(logs[3].msg, 'counter: 1')
+  })
+})


### PR DESCRIPTION
## Summary
- Bind all public methods in constructor to maintain 'this' context when destructured
- Add tests for destructured method usage

## Test plan
- All existing tests pass
- New tests verify destructured methods work correctly